### PR TITLE
Swap order of lat/lng in decode to match geojson

### DIFF
--- a/polyline.js
+++ b/polyline.js
@@ -80,7 +80,7 @@ polyline.decode = function(str, precision) {
         lat += latitude_change;
         lng += longitude_change;
 
-        coordinates.push([lat / factor, lng / factor]);
+        coordinates.push([lng / factor, lat / factor]);
     }
 
     return coordinates;


### PR DESCRIPTION
GeoJSON defines points as [lng,lat] so this swaps them around in the decode so that things are mapped out correctly.